### PR TITLE
STNetTaskQueue: updates

### DIFF
--- a/STNetTaskQueue.podspec
+++ b/STNetTaskQueue.podspec
@@ -17,12 +17,6 @@ Pod::Spec.new do |s|
   s.resources = "STNetTaskQueue/*.xcdatamodeld"
   s.frameworks = "CoreData"
 
-  s.resource_bundles = {
-    "STNetTaskQueue" => [
-      'Pod/**/*.xcdatamodeld'
-    ]
-  }
-
   s.source_files = "STNetTaskQueue/*.{h,m}"
   s.public_header_files = "STNetTaskQueue/*.h"
 end

--- a/STNetTaskQueue.podspec
+++ b/STNetTaskQueue.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author       = { "Kevin Lin" => "kevin_lyn@outlook.com" }
 
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/kevin0571/STNetTaskQueue.git", :tag => s.version }
+  s.source       = { :git => "https://github.com/osorochich/STNetTaskQueue.git", :branch => "offline_cache" }
 
   s.source_files = "STNetTaskQueue/*.{h,m}"
   s.public_header_files = "STNetTaskQueue/*.h"

--- a/STNetTaskQueue.podspec
+++ b/STNetTaskQueue.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author       = { "Kevin Lin" => "kevin_lyn@outlook.com" }
 
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/kevin0571/STNetTaskQueue.git", :tag => s.version }
+  s.source       = { :git => "https://github.com/osorochich/STNetTaskQueue.git", :branch => "implement_block_based_functionality" }
 
   s.source_files = "STNetTaskQueue/*.{h,m}"
   s.public_header_files = "STNetTaskQueue/*.h"

--- a/STNetTaskQueue.podspec
+++ b/STNetTaskQueue.podspec
@@ -14,6 +14,15 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/osorochich/STNetTaskQueue.git", :branch => "offline_cache" }
 
+  s.resources = "STNetTaskQueue/*.xcdatamodeld"
+  s.frameworks = "CoreData"
+
+  s.resource_bundles = {
+    "STNetTaskQueue" => [
+      'Pod/**/*.xcdatamodeld'
+    ]
+  }
+
   s.source_files = "STNetTaskQueue/*.{h,m}"
   s.public_header_files = "STNetTaskQueue/*.h"
 end

--- a/STNetTaskQueue.xcodeproj/project.pbxproj
+++ b/STNetTaskQueue.xcodeproj/project.pbxproj
@@ -31,7 +31,7 @@
 		7B1333A91D29438F00DA5E58 /* STWebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B1333A71D29438F00DA5E58 /* STWebCache.m */; };
 		7B1333AD1D29455300DA5E58 /* STBaseCoreDataStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B1333AB1D29455300DA5E58 /* STBaseCoreDataStorage.h */; };
 		7B1333AE1D29455300DA5E58 /* STBaseCoreDataStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B1333AC1D29455300DA5E58 /* STBaseCoreDataStorage.m */; };
-		7B1333B01D295E4800DA5E58 /* WebCache.xcdatamodeld in Resources */ = {isa = PBXBuildFile; fileRef = 7B1333961D2941FC00DA5E58 /* WebCache.xcdatamodeld */; };
+		7B1333B11D29669C00DA5E58 /* WebCache.xcdatamodeld in Resources */ = {isa = PBXBuildFile; fileRef = 7B1333961D2941FC00DA5E58 /* WebCache.xcdatamodeld */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -249,7 +249,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7B1333B01D295E4800DA5E58 /* WebCache.xcdatamodeld in Resources */,
+				7B1333B11D29669C00DA5E58 /* WebCache.xcdatamodeld in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/STNetTaskQueue.xcodeproj/project.pbxproj
+++ b/STNetTaskQueue.xcodeproj/project.pbxproj
@@ -27,6 +27,10 @@
 		7B13339B1D29426E00DA5E58 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B13339A1D29426E00DA5E58 /* CoreData.framework */; };
 		7B1333A31D2942AB00DA5E58 /* STWebURLResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B13339F1D2942AB00DA5E58 /* STWebURLResponse.h */; };
 		7B1333A41D2942AB00DA5E58 /* STWebURLResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B1333A01D2942AB00DA5E58 /* STWebURLResponse.m */; };
+		7B1333A81D29438F00DA5E58 /* STWebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B1333A61D29438F00DA5E58 /* STWebCache.h */; };
+		7B1333A91D29438F00DA5E58 /* STWebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B1333A71D29438F00DA5E58 /* STWebCache.m */; };
+		7B1333AD1D29455300DA5E58 /* STBaseCoreDataStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B1333AB1D29455300DA5E58 /* STBaseCoreDataStorage.h */; };
+		7B1333AE1D29455300DA5E58 /* STBaseCoreDataStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B1333AC1D29455300DA5E58 /* STBaseCoreDataStorage.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -52,6 +56,10 @@
 		7B13339A1D29426E00DA5E58 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		7B13339F1D2942AB00DA5E58 /* STWebURLResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STWebURLResponse.h; sourceTree = "<group>"; };
 		7B1333A01D2942AB00DA5E58 /* STWebURLResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STWebURLResponse.m; sourceTree = "<group>"; };
+		7B1333A61D29438F00DA5E58 /* STWebCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STWebCache.h; sourceTree = "<group>"; };
+		7B1333A71D29438F00DA5E58 /* STWebCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STWebCache.m; sourceTree = "<group>"; };
+		7B1333AB1D29455300DA5E58 /* STBaseCoreDataStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STBaseCoreDataStorage.h; sourceTree = "<group>"; };
+		7B1333AC1D29455300DA5E58 /* STBaseCoreDataStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STBaseCoreDataStorage.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -119,6 +127,8 @@
 		7B1333951D2941E000DA5E58 /* Cache */ = {
 			isa = PBXGroup;
 			children = (
+				7B1333AA1D29453800DA5E58 /* Base Storage */,
+				7B1333A51D29437400DA5E58 /* Manager */,
 				7B13339C1D29429000DA5E58 /* Model */,
 				7B1333991D29424F00DA5E58 /* CoreData Model */,
 			);
@@ -142,6 +152,24 @@
 			name = Model;
 			sourceTree = "<group>";
 		};
+		7B1333A51D29437400DA5E58 /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				7B1333A61D29438F00DA5E58 /* STWebCache.h */,
+				7B1333A71D29438F00DA5E58 /* STWebCache.m */,
+			);
+			name = Manager;
+			sourceTree = "<group>";
+		};
+		7B1333AA1D29453800DA5E58 /* Base Storage */ = {
+			isa = PBXGroup;
+			children = (
+				7B1333AB1D29455300DA5E58 /* STBaseCoreDataStorage.h */,
+				7B1333AC1D29455300DA5E58 /* STBaseCoreDataStorage.m */,
+			);
+			name = "Base Storage";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -152,11 +180,13 @@
 				76012C6E1C265EC50090BE94 /* STHTTPNetTask.h in Headers */,
 				76012C761C265EC50090BE94 /* STNetTaskChain.h in Headers */,
 				76012C741C265EC50090BE94 /* STNetTask.h in Headers */,
+				7B1333A81D29438F00DA5E58 /* STWebCache.h in Headers */,
 				76012C781C265EC50090BE94 /* STNetTaskQueue.h in Headers */,
 				7645D0FF1CDF66D5000ED54A /* STNetTaskGroup.h in Headers */,
 				76012C721C265EC50090BE94 /* STHTTPNetTaskQueueHandler.h in Headers */,
 				76012C7A1C265EC50090BE94 /* STNetTaskQueueLog.h in Headers */,
 				7B1333A31D2942AB00DA5E58 /* STWebURLResponse.h in Headers */,
+				7B1333AD1D29455300DA5E58 /* STBaseCoreDataStorage.h in Headers */,
 				76012C701C265EC50090BE94 /* STHTTPNetTaskParametersPacker.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -232,11 +262,13 @@
 				7645D1001CDF66D5000ED54A /* STNetTaskGroup.m in Sources */,
 				76012C7B1C265EC50090BE94 /* STNetTaskQueueLog.m in Sources */,
 				76012C711C265EC50090BE94 /* STHTTPNetTaskParametersPacker.m in Sources */,
+				7B1333AE1D29455300DA5E58 /* STBaseCoreDataStorage.m in Sources */,
 				76012C771C265EC50090BE94 /* STNetTaskChain.m in Sources */,
 				7B1333A41D2942AB00DA5E58 /* STWebURLResponse.m in Sources */,
 				76012C731C265EC50090BE94 /* STHTTPNetTaskQueueHandler.m in Sources */,
 				76012C751C265EC50090BE94 /* STNetTask.m in Sources */,
 				7B1333981D2941FC00DA5E58 /* WebCache.xcdatamodeld in Sources */,
+				7B1333A91D29438F00DA5E58 /* STWebCache.m in Sources */,
 				76012C791C265EC50090BE94 /* STNetTaskQueue.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/STNetTaskQueue.xcodeproj/project.pbxproj
+++ b/STNetTaskQueue.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		7B1333A91D29438F00DA5E58 /* STWebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B1333A71D29438F00DA5E58 /* STWebCache.m */; };
 		7B1333AD1D29455300DA5E58 /* STBaseCoreDataStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B1333AB1D29455300DA5E58 /* STBaseCoreDataStorage.h */; };
 		7B1333AE1D29455300DA5E58 /* STBaseCoreDataStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B1333AC1D29455300DA5E58 /* STBaseCoreDataStorage.m */; };
+		7B1333B01D295E4800DA5E58 /* WebCache.xcdatamodeld in Resources */ = {isa = PBXBuildFile; fileRef = 7B1333961D2941FC00DA5E58 /* WebCache.xcdatamodeld */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -248,6 +249,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7B1333B01D295E4800DA5E58 /* WebCache.xcdatamodeld in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/STNetTaskQueue.xcodeproj/project.pbxproj
+++ b/STNetTaskQueue.xcodeproj/project.pbxproj
@@ -23,6 +23,10 @@
 		76012C7B1C265EC50090BE94 /* STNetTaskQueueLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 76012C6D1C265EC50090BE94 /* STNetTaskQueueLog.m */; };
 		7645D0FF1CDF66D5000ED54A /* STNetTaskGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 7645D0FD1CDF66D5000ED54A /* STNetTaskGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7645D1001CDF66D5000ED54A /* STNetTaskGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 7645D0FE1CDF66D5000ED54A /* STNetTaskGroup.m */; };
+		7B1333981D2941FC00DA5E58 /* WebCache.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 7B1333961D2941FC00DA5E58 /* WebCache.xcdatamodeld */; };
+		7B13339B1D29426E00DA5E58 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B13339A1D29426E00DA5E58 /* CoreData.framework */; };
+		7B1333A31D2942AB00DA5E58 /* STWebURLResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B13339F1D2942AB00DA5E58 /* STWebURLResponse.h */; };
+		7B1333A41D2942AB00DA5E58 /* STWebURLResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B1333A01D2942AB00DA5E58 /* STWebURLResponse.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +48,10 @@
 		76012C6D1C265EC50090BE94 /* STNetTaskQueueLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STNetTaskQueueLog.m; sourceTree = "<group>"; };
 		7645D0FD1CDF66D5000ED54A /* STNetTaskGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STNetTaskGroup.h; sourceTree = "<group>"; };
 		7645D0FE1CDF66D5000ED54A /* STNetTaskGroup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STNetTaskGroup.m; sourceTree = "<group>"; };
+		7B1333971D2941FC00DA5E58 /* WebCache.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = WebCache.xcdatamodel; sourceTree = "<group>"; };
+		7B13339A1D29426E00DA5E58 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		7B13339F1D2942AB00DA5E58 /* STWebURLResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STWebURLResponse.h; sourceTree = "<group>"; };
+		7B1333A01D2942AB00DA5E58 /* STWebURLResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STWebURLResponse.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -51,6 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7B13339B1D29426E00DA5E58 /* CoreData.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -60,6 +69,7 @@
 		76012C4B1C265A160090BE94 = {
 			isa = PBXGroup;
 			children = (
+				7B13339A1D29426E00DA5E58 /* CoreData.framework */,
 				76012C571C265A160090BE94 /* STNetTaskQueue */,
 				76012C561C265A160090BE94 /* Products */,
 			);
@@ -76,6 +86,7 @@
 		76012C571C265A160090BE94 /* STNetTaskQueue */ = {
 			isa = PBXGroup;
 			children = (
+				7B1333951D2941E000DA5E58 /* Cache */,
 				76012C7C1C265F6E0090BE94 /* HTTP */,
 				76012C661C265EC50090BE94 /* STNetTask.h */,
 				76012C671C265EC50090BE94 /* STNetTask.m */,
@@ -105,6 +116,32 @@
 			name = HTTP;
 			sourceTree = "<group>";
 		};
+		7B1333951D2941E000DA5E58 /* Cache */ = {
+			isa = PBXGroup;
+			children = (
+				7B13339C1D29429000DA5E58 /* Model */,
+				7B1333991D29424F00DA5E58 /* CoreData Model */,
+			);
+			name = Cache;
+			sourceTree = "<group>";
+		};
+		7B1333991D29424F00DA5E58 /* CoreData Model */ = {
+			isa = PBXGroup;
+			children = (
+				7B1333961D2941FC00DA5E58 /* WebCache.xcdatamodeld */,
+			);
+			name = "CoreData Model";
+			sourceTree = "<group>";
+		};
+		7B13339C1D29429000DA5E58 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				7B13339F1D2942AB00DA5E58 /* STWebURLResponse.h */,
+				7B1333A01D2942AB00DA5E58 /* STWebURLResponse.m */,
+			);
+			name = Model;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -119,6 +156,7 @@
 				7645D0FF1CDF66D5000ED54A /* STNetTaskGroup.h in Headers */,
 				76012C721C265EC50090BE94 /* STHTTPNetTaskQueueHandler.h in Headers */,
 				76012C7A1C265EC50090BE94 /* STNetTaskQueueLog.h in Headers */,
+				7B1333A31D2942AB00DA5E58 /* STWebURLResponse.h in Headers */,
 				76012C701C265EC50090BE94 /* STHTTPNetTaskParametersPacker.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -195,8 +233,10 @@
 				76012C7B1C265EC50090BE94 /* STNetTaskQueueLog.m in Sources */,
 				76012C711C265EC50090BE94 /* STHTTPNetTaskParametersPacker.m in Sources */,
 				76012C771C265EC50090BE94 /* STNetTaskChain.m in Sources */,
+				7B1333A41D2942AB00DA5E58 /* STWebURLResponse.m in Sources */,
 				76012C731C265EC50090BE94 /* STHTTPNetTaskQueueHandler.m in Sources */,
 				76012C751C265EC50090BE94 /* STNetTask.m in Sources */,
+				7B1333981D2941FC00DA5E58 /* WebCache.xcdatamodeld in Sources */,
 				76012C791C265EC50090BE94 /* STNetTaskQueue.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -348,6 +388,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		7B1333961D2941FC00DA5E58 /* WebCache.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				7B1333971D2941FC00DA5E58 /* WebCache.xcdatamodel */,
+			);
+			currentVersion = 7B1333971D2941FC00DA5E58 /* WebCache.xcdatamodel */;
+			path = WebCache.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 76012C4C1C265A160090BE94 /* Project object */;
 }

--- a/STNetTaskQueue.xcodeproj/project.pbxproj
+++ b/STNetTaskQueue.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		76012C7B1C265EC50090BE94 /* STNetTaskQueueLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 76012C6D1C265EC50090BE94 /* STNetTaskQueueLog.m */; };
 		7645D0FF1CDF66D5000ED54A /* STNetTaskGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 7645D0FD1CDF66D5000ED54A /* STNetTaskGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7645D1001CDF66D5000ED54A /* STNetTaskGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 7645D0FE1CDF66D5000ED54A /* STNetTaskGroup.m */; };
+		7B1333B41D297E1C00DA5E58 /* STNetTask+Management.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B1333B21D297E1C00DA5E58 /* STNetTask+Management.h */; };
+		7B1333B51D297E1C00DA5E58 /* STNetTask+Management.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B1333B31D297E1C00DA5E58 /* STNetTask+Management.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +46,8 @@
 		76012C6D1C265EC50090BE94 /* STNetTaskQueueLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STNetTaskQueueLog.m; sourceTree = "<group>"; };
 		7645D0FD1CDF66D5000ED54A /* STNetTaskGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STNetTaskGroup.h; sourceTree = "<group>"; };
 		7645D0FE1CDF66D5000ED54A /* STNetTaskGroup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STNetTaskGroup.m; sourceTree = "<group>"; };
+		7B1333B21D297E1C00DA5E58 /* STNetTask+Management.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "STNetTask+Management.h"; sourceTree = "<group>"; };
+		7B1333B31D297E1C00DA5E58 /* STNetTask+Management.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "STNetTask+Management.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -88,6 +92,8 @@
 				7645D0FD1CDF66D5000ED54A /* STNetTaskGroup.h */,
 				7645D0FE1CDF66D5000ED54A /* STNetTaskGroup.m */,
 				76012C5A1C265A160090BE94 /* Info.plist */,
+				7B1333B21D297E1C00DA5E58 /* STNetTask+Management.h */,
+				7B1333B31D297E1C00DA5E58 /* STNetTask+Management.m */,
 			);
 			path = STNetTaskQueue;
 			sourceTree = "<group>";
@@ -113,6 +119,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				76012C6E1C265EC50090BE94 /* STHTTPNetTask.h in Headers */,
+				7B1333B41D297E1C00DA5E58 /* STNetTask+Management.h in Headers */,
 				76012C761C265EC50090BE94 /* STNetTaskChain.h in Headers */,
 				76012C741C265EC50090BE94 /* STNetTask.h in Headers */,
 				76012C781C265EC50090BE94 /* STNetTaskQueue.h in Headers */,
@@ -195,6 +202,7 @@
 				76012C7B1C265EC50090BE94 /* STNetTaskQueueLog.m in Sources */,
 				76012C711C265EC50090BE94 /* STHTTPNetTaskParametersPacker.m in Sources */,
 				76012C771C265EC50090BE94 /* STNetTaskChain.m in Sources */,
+				7B1333B51D297E1C00DA5E58 /* STNetTask+Management.m in Sources */,
 				76012C731C265EC50090BE94 /* STHTTPNetTaskQueueHandler.m in Sources */,
 				76012C751C265EC50090BE94 /* STNetTask.m in Sources */,
 				76012C791C265EC50090BE94 /* STNetTaskQueue.m in Sources */,

--- a/STNetTaskQueue/STBaseCoreDataStorage.h
+++ b/STNetTaskQueue/STBaseCoreDataStorage.h
@@ -1,0 +1,31 @@
+//
+//  STBaseCoreDataStorage.h
+//  STNetTaskQueue
+//
+//  Created by Oleg Sorochich on 7/3/16.
+//  Copyright © 2016 Sth4Me. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@interface STBaseCoreDataStorage : NSObject
+
+@property (atomic, copy, readonly) NSString *storeName;
+
+@property (readonly, strong, nonatomic) NSManagedObjectModel *model;
+@property (readonly, strong, nonatomic) NSPersistentStoreCoordinator *coordinator;
+@property (readonly, strong, nonatomic) NSManagedObjectContext *mainContext;
+
+- (instancetype)initWithStoreName:(NSString *)storeName;
+
+- (NSArray *)recordsWithName:(NSString *)name predicate:(NSPredicate *)predicate;
+- (id)insertObjectWithClass:(Class)objectClass;
+- (void)deleteRecords:(NSArray *)records;
+
+- (id)executeBlockInPrivate:(id(^)())block;
+- (id)executeBlockInMain:(id(^)())block;
+
+- (void)save;
+
+@end

--- a/STNetTaskQueue/STBaseCoreDataStorage.m
+++ b/STNetTaskQueue/STBaseCoreDataStorage.m
@@ -1,0 +1,184 @@
+//
+//  STBaseCoreDataStorage.m
+//  STNetTaskQueue
+//
+//  Created by Oleg Sorochich on 7/3/16.
+//  Copyright © 2016 Sth4Me. All rights reserved.
+//
+
+#import "STBaseCoreDataStorage.h"
+
+@interface STBaseCoreDataStorage () {
+    @private
+    void *_queueTag;
+}
+
+@property (atomic, copy, readwrite) NSString *storeName;
+
+@property (readwrite, strong, nonatomic) NSManagedObjectModel *model;
+@property (readwrite, strong, nonatomic) NSPersistentStoreCoordinator *coordinator;
+
+@property (readwrite, strong, nonatomic) NSManagedObjectContext *mainContext;
+@property (nonatomic, weak) NSManagedObjectContext *currentContext;
+@property (nonatomic, strong) NSManagedObjectContext *privateContext;
+
+@property (nonatomic, strong) dispatch_queue_t privateQueue;
+
+
+@end
+
+@implementation STBaseCoreDataStorage
+
+#pragma mark - Initialization
+
+- (instancetype)initWithStoreName:(NSString *)storeName {
+    self = [super init];
+ 
+    if (self) {
+        self.storeName = storeName;
+       
+        [self setUpQueue];
+        [self setUpModel];
+        [self setUpCoordinator];
+        [self setUpMainContext];
+        [self setUpPrivateContext];
+        
+        self.currentContext = self.privateContext;
+    }
+    
+    return self;
+}
+
+#pragma mark - Public interface
+
+- (NSArray *)recordsWithName:(NSString*)name predicate:(NSPredicate*)predicate {
+    return [self executeBlock:^() {
+        NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
+        NSEntityDescription *entity = [NSEntityDescription entityForName:name inManagedObjectContext:_currentContext];
+        [fetchRequest setEntity:entity];
+        fetchRequest.predicate = predicate;
+
+        NSArray *records = [_currentContext executeFetchRequest:fetchRequest error:nil];
+        return records;
+    }];
+}
+
+- (id)insertObjectWithClass:(Class)objectClass {
+    return [NSEntityDescription insertNewObjectForEntityForName:NSStringFromClass(objectClass)
+                                         inManagedObjectContext:_currentContext];
+}
+
+- (void)deleteRecords:(NSArray *)records {
+    for(NSManagedObject* record in records) {
+        [_currentContext deleteObject:record];
+    }
+}
+
+- (id)executeBlockInPrivate:(id(^)())block {
+    
+    @synchronized(self) {
+        __block id result;
+        dispatch_sync(_privateQueue, ^() {
+            @autoreleasepool {
+                result = block();
+            }
+        });
+        return result;
+    }
+}
+
+- (id)executeBlockInMain:(id(^)())block {
+    
+    @synchronized(self) {
+        _currentContext = _mainContext;
+        id result = block();
+        _currentContext = _privateContext;
+        return result;
+    }
+}
+
+- (void)save {
+    
+    NSError* error = nil;
+    [_currentContext save:&error];
+    NSAssert(error == nil, @"saving error: %@", error);
+}
+
+#pragma mark - Private interface
+
+- (id)executeBlock:(id(^)())block {
+    
+    __block id result;
+    
+    dispatch_sync(_privateQueue, ^() {
+        @autoreleasepool {
+            result = block();
+        }
+    });
+    return result;
+}
+
+- (void)setUpQueue {
+    self.privateQueue = dispatch_queue_create([_storeName cStringUsingEncoding:NSUTF8StringEncoding], DISPATCH_QUEUE_CONCURRENT);
+    _queueTag = &_queueTag;
+    dispatch_queue_set_specific(_privateQueue, _queueTag, _queueTag, NULL);
+}
+
+- (void)setUpMainContext {
+    if (_mainContext != nil) {
+        return;
+    }
+    if (_coordinator != nil) {
+        _mainContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
+        [_mainContext setPersistentStoreCoordinator:_coordinator];
+    }
+}
+
+- (void)setUpPrivateContext {
+    
+    if (_privateContext != nil) {
+        return;
+    }
+    if (_coordinator != nil) {
+        _privateContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
+        [_privateContext setPersistentStoreCoordinator:_coordinator];
+    }
+}
+
+- (void)setUpModel {
+    
+    [self executeBlock:^() {
+        if (_model != nil) {
+            return (id)nil;
+        }
+        NSURL *modelURL = [[NSBundle mainBundle] URLForResource:_storeName withExtension:@"momd"];
+        if(modelURL == nil) {
+            modelURL = [[NSBundle mainBundle] URLForResource:_storeName withExtension:@"mom"];
+        }
+        _model = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelURL];
+        return (id)nil;
+    }];
+}
+
+- (void)setUpCoordinator {
+    
+    [self executeBlock:^() {
+        if (_coordinator != nil) {
+            return (id)nil;
+        }
+        NSURL *storeURL = [[self applicationDocumentsDirectory]
+                           URLByAppendingPathComponent:[NSString stringWithFormat:@"%@.sqlite", self.storeName]];
+        NSError *error = nil;
+        _coordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:_model];
+        if (![_coordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:storeURL options:nil error:&error]) {
+            NSAssert(NO, @"Unresolved error %@, %@", error, [error userInfo]);
+        }
+        return (id)nil;
+    }];
+}
+
+- (NSURL *)applicationDocumentsDirectory {
+    return [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
+}
+
+@end

--- a/STNetTaskQueue/STBaseCoreDataStorage.m
+++ b/STNetTaskQueue/STBaseCoreDataStorage.m
@@ -152,7 +152,7 @@
             return (id)nil;
         }
         
-        NSBundle *bundle = [NSBundle bundleWithIdentifier:@"STNetTaskQueue"];
+        NSBundle *bundle = [NSBundle bundleForClass:[self classForCoder]];
         
         NSURL *modelURL = [bundle URLForResource:_storeName withExtension:@"momd"];
         if(modelURL == nil) {

--- a/STNetTaskQueue/STBaseCoreDataStorage.m
+++ b/STNetTaskQueue/STBaseCoreDataStorage.m
@@ -151,9 +151,12 @@
         if (_model != nil) {
             return (id)nil;
         }
-        NSURL *modelURL = [[NSBundle mainBundle] URLForResource:_storeName withExtension:@"momd"];
+        
+        NSBundle *bundle = [NSBundle bundleWithIdentifier:@"STNetTaskQueue"];
+        
+        NSURL *modelURL = [bundle URLForResource:_storeName withExtension:@"momd"];
         if(modelURL == nil) {
-            modelURL = [[NSBundle mainBundle] URLForResource:_storeName withExtension:@"mom"];
+            modelURL = [bundle URLForResource:_storeName withExtension:@"mom"];
         }
         _model = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelURL];
         return (id)nil;

--- a/STNetTaskQueue/STHTTPNetTaskQueueHandler.m
+++ b/STNetTaskQueue/STHTTPNetTaskQueueHandler.m
@@ -199,7 +199,7 @@ static NSMapTable *STHTTPNetTaskToSessionTask;
             [_queue task:_task didFailWithError:error];
         }
         else {
-            if (_task.useOffileCache) {
+            if (_task.useOfflineCache) {
                 [_queue.cache saveResponseWithData:data forURL:_task.uri];
             }
             [_queue task:_task didResponse:responseObj];
@@ -217,7 +217,7 @@ static NSMapTable *STHTTPNetTaskToSessionTask;
             [STNetTaskQueueLog log:@"\n%@", _task.description];
         }
         
-        if (_task.useOffileCache && [error isNoInternetConnectionError]) {
+        if (_task.useOfflineCache && [error isNoInternetConnectionError]) {
             NSData *responseData = [_queue.cache responseDataForUrl:_task.uri];
             id responseObj = [self responseFromData:responseData forTask:_task];
             

--- a/STNetTaskQueue/STNetTask+Management.h
+++ b/STNetTaskQueue/STNetTask+Management.h
@@ -1,0 +1,23 @@
+//
+//  STNetTask+Management.h
+//  STNetTaskQueue
+//
+//  Created by Oleg Sorochich on 7/3/16.
+//  Copyright © 2016 Sth4Me. All rights reserved.
+//
+
+#import "STNetTask.h"
+
+@interface STNetTask (Management)
+
+/**
+ This method is used to start the task
+ */
+- (void)start;
+
+/**
+ This method is used to cancel the task
+ */
+- (void)cancel;
+
+@end

--- a/STNetTaskQueue/STNetTask+Management.m
+++ b/STNetTaskQueue/STNetTask+Management.m
@@ -1,0 +1,24 @@
+//
+//  STNetTask+Management.m
+//  STNetTaskQueue
+//
+//  Created by Oleg Sorochich on 7/3/16.
+//  Copyright © 2016 Sth4Me. All rights reserved.
+//
+
+#import "STNetTask+Management.h"
+#import "STNetTaskQueue.h"
+
+
+@implementation STNetTask (Management)
+
+- (void)start {
+    [[STNetTaskQueue sharedQueue] addTask:self];
+}
+
+
+- (void)cancel {
+    [[STNetTaskQueue sharedQueue] cancelTask:self];
+}
+
+@end

--- a/STNetTaskQueue/STNetTask.h
+++ b/STNetTaskQueue/STNetTask.h
@@ -79,9 +79,10 @@ typedef void (^STNetTaskSubscriptionBlock)();
 
 
 /**
- Indicates if the net task should cache a request. In case if request is failed and cache exists, the task should be finished with the last cached data.
+ Indicates if the net task should cache a request. 
+ In case if request is failed by internet connection error and cache exists, the task should be finished with the last cached data which is specified for the task.uri.
  */
-@property (atomic, assign, readonly) BOOL useCachedData;
+@property (atomic, assign, readonly) BOOL useOffileCache;
 
 /**
  A unique string represents the net task.

--- a/STNetTaskQueue/STNetTask.h
+++ b/STNetTaskQueue/STNetTask.h
@@ -28,6 +28,20 @@ FOUNDATION_EXPORT NSString *const STNetTaskUnknownError;
 
 @class STNetTask;
 
+typedef void (^STNetTaskCompletionBlock)(STNetTask *task);
+
+@protocol STNetTaskBlockBasedContract <NSObject>
+
+/**
+ This handler will be called if STNetTask subclass implements STNetTaskBlockBasedContract.
+ If the next task is failed, task.error will be non-nil.
+ 
+ In case if class implements STNetTaskBlockBasedContract, but completion handler is nil, 'netTaskDidEnd:' method will be triggered.
+ */
+@property (nonatomic, copy) STNetTaskCompletionBlock completionHandler;
+
+@end
+
 @protocol STNetTaskDelegate <NSObject>
 
 /**

--- a/STNetTaskQueue/STNetTask.h
+++ b/STNetTaskQueue/STNetTask.h
@@ -77,6 +77,12 @@ typedef void (^STNetTaskSubscriptionBlock)();
  */
 @property (atomic, assign, readonly) NSUInteger retryCount;
 
+
+/**
+ Indicates if the net task should cache a request. In case if request is failed and cache exists, the task should be finished with the last cached data.
+ */
+@property (atomic, assign, readonly) BOOL useCachedData;
+
 /**
  A unique string represents the net task.
  

--- a/STNetTaskQueue/STNetTask.h
+++ b/STNetTaskQueue/STNetTask.h
@@ -82,7 +82,7 @@ typedef void (^STNetTaskSubscriptionBlock)();
  Indicates if the net task should cache a request. 
  In case if request is failed by internet connection error and cache exists, the task should be finished with the last cached data which is specified for the task.uri.
  */
-@property (atomic, assign, readonly) BOOL useOffileCache;
+@property (atomic, assign, readwrite) BOOL useOffileCache;
 
 /**
  A unique string represents the net task.

--- a/STNetTaskQueue/STNetTask.h
+++ b/STNetTaskQueue/STNetTask.h
@@ -82,7 +82,7 @@ typedef void (^STNetTaskSubscriptionBlock)();
  Indicates if the net task should cache a request. 
  In case if request is failed by internet connection error and cache exists, the task should be finished with the last cached data which is specified for the task.uri.
  */
-@property (atomic, assign, readwrite) BOOL useOffileCache;
+@property (atomic, assign, readwrite) BOOL useOfflineCache;
 
 /**
  A unique string represents the net task.

--- a/STNetTaskQueue/STNetTask.m
+++ b/STNetTaskQueue/STNetTask.m
@@ -15,6 +15,8 @@ NSString *const STNetTaskUnknownError = @"STNetTaskUnknownError";
 @property (atomic, assign) BOOL pending;
 @property (atomic, assign) BOOL cancelled;
 @property (atomic, assign) BOOL finished;
+@property (atomic, assign) BOOL useCachedData;
+
 @property (atomic, assign) NSUInteger retryCount;
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSMutableArray<STNetTaskSubscriptionBlock> *> *stateToBlock;
 

--- a/STNetTaskQueue/STNetTask.m
+++ b/STNetTaskQueue/STNetTask.m
@@ -15,7 +15,6 @@ NSString *const STNetTaskUnknownError = @"STNetTaskUnknownError";
 @property (atomic, assign) BOOL pending;
 @property (atomic, assign) BOOL cancelled;
 @property (atomic, assign) BOOL finished;
-@property (atomic, assign) BOOL useCachedData;
 
 @property (atomic, assign) NSUInteger retryCount;
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSMutableArray<STNetTaskSubscriptionBlock> *> *stateToBlock;

--- a/STNetTaskQueue/STNetTaskQueue.h
+++ b/STNetTaskQueue/STNetTaskQueue.h
@@ -50,6 +50,11 @@ FOUNDATION_EXPORT const unsigned char STNetTaskQueueVersionString[];
 @interface STNetTaskQueue : NSObject
 
 /**
+  Indicates amount of days for cached responses. By default it is equal to 3 days.
+*/
+@property (nonatomic, assign) NSUInteger cachedResponsesDuration;
+
+/**
  The STNetTaskQueueHandler which is used for handling the net tasks in queue.
  */
 @property (nonatomic, strong) id<STNetTaskQueueHandler> handler;

--- a/STNetTaskQueue/STNetTaskQueue.h
+++ b/STNetTaskQueue/STNetTaskQueue.h
@@ -50,7 +50,7 @@ FOUNDATION_EXPORT const unsigned char STNetTaskQueueVersionString[];
 @interface STNetTaskQueue : NSObject
 
 /**
-  Indicates amount of days for cached responses. By default it is equal to 3 days.
+  Indicates count of days for cached responses. By default it is equal to 3 days.
 */
 @property (nonatomic, assign) NSUInteger cachedResponsesDuration;
 

--- a/STNetTaskQueue/STNetTaskQueue.h
+++ b/STNetTaskQueue/STNetTaskQueue.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 @class STNetTask;
+@class STWebCache;
 @protocol STNetTaskDelegate;
 
 //! Project version number for STNetTaskQueue.
@@ -53,6 +54,12 @@ FOUNDATION_EXPORT const unsigned char STNetTaskQueueVersionString[];
   Indicates count of days for cached responses. By default it is equal to 3 days.
 */
 @property (nonatomic, assign) NSUInteger cachedResponsesDuration;
+
+/**
+ A cache for responses. Set task.useOfflineCache to enabling response caching.
+ User cache.clean() to manually clean the cache.
+*/
+@property (nonatomic, readonly, strong) STWebCache *cache;
 
 /**
  The STNetTaskQueueHandler which is used for handling the net tasks in queue.

--- a/STNetTaskQueue/STNetTaskQueue.m
+++ b/STNetTaskQueue/STNetTaskQueue.m
@@ -138,12 +138,6 @@
 
 - (BOOL)_retryTask:(STNetTask *)task withError:(NSError *)error
 {
-    if (task.useOffileCache) {
-        NSData *response = [self.cache responseDataForUrl:task.uri];
-        [self task:task didResponse:response];
-        return YES;
-    }
-    
     if ([task shouldRetryForError:error] && task.retryCount < task.maxRetryCount) {
         task.retryCount++;
         [self performSelector:@selector(_retryTask:) withObject:task afterDelay:task.retryInterval];
@@ -201,11 +195,7 @@
         task.error = error;
         [task didFail];
     }
-    
-    if (task.useOffileCache) {
-        [self.cache saveResponseWithData:response forURL:task.uri];
-    }
-    
+
     task.pending = NO;
     task.finished = YES;
     [task notifyState:STNetTaskStateFinished];
@@ -328,19 +318,6 @@
     [delegates removeObject:delegate];
     
     [self.lock unlock];
-}
-
-@end
-
-@interface NSError (NoConnection)
-- (BOOL)isNoInternetConnectionError;
-@end
-
-@implementation NSError (NoConnection)
-
-- (BOOL)isNoInternetConnectionError
-{
-    return ([self.domain isEqualToString:NSURLErrorDomain] && (self.code == NSURLErrorNotConnectedToInternet));
 }
 
 @end

--- a/STNetTaskQueue/STNetTaskQueue.m
+++ b/STNetTaskQueue/STNetTaskQueue.m
@@ -227,6 +227,19 @@
 
 - (void)_netTaskDidEnd:(STNetTask *)task
 {
+    if ([task conformsToProtocol:@protocol(STNetTaskBlockBasedContract)]) {
+        id<STNetTaskBlockBasedContract> blockTask = (STNetTask<STNetTaskBlockBasedContract> *)task;
+        if (blockTask.completionHandler != nil) {
+            
+            dispatch_async(dispatch_get_main_queue(), ^ {
+                blockTask.completionHandler(task);
+            });
+            
+            return;
+        }
+        
+    }
+    
     [self.lock lock];
     
     NSHashTable *delegatesForURI = self.taskDelegates[task.uri];

--- a/STNetTaskQueue/STWebCache.h
+++ b/STNetTaskQueue/STWebCache.h
@@ -1,0 +1,21 @@
+//
+//  STWebCache.h
+//  STNetTaskQueue
+//
+//  Created by Oleg Sorochich on 7/3/16.
+//  Copyright © 2016 Sth4Me. All rights reserved.
+//
+
+#import "STBaseCoreDataStorage.h"
+
+@interface STWebCache : STBaseCoreDataStorage
+
+/**
+ Indicates duration for cached responses. All responses older than duration time will be cleaned.
+*/
+@property (nonatomic, assign) NSUInteger cacheDaysDuration;
+
+- (void)saveURLResponseWithData:(NSData *)data forURL:(NSString*)url;
+- (NSData *)responseDataForUrl:(NSString *)url;
+
+@end

--- a/STNetTaskQueue/STWebCache.h
+++ b/STNetTaskQueue/STWebCache.h
@@ -20,4 +20,6 @@
 - (void)saveResponseWithData:(NSData *)data forURL:(NSString*)url;
 - (NSData *)responseDataForUrl:(NSString *)url;
 
+- (void)clean;
+
 @end

--- a/STNetTaskQueue/STWebCache.h
+++ b/STNetTaskQueue/STWebCache.h
@@ -15,7 +15,9 @@
 */
 @property (nonatomic, assign) NSUInteger cacheDaysDuration;
 
-- (void)saveURLResponseWithData:(NSData *)data forURL:(NSString*)url;
++ (STWebCache *)sharedInstance;
+
+- (void)saveResponseWithData:(NSData *)data forURL:(NSString*)url;
 - (NSData *)responseDataForUrl:(NSString *)url;
 
 @end

--- a/STNetTaskQueue/STWebCache.m
+++ b/STNetTaskQueue/STWebCache.m
@@ -1,0 +1,91 @@
+//
+//  STWebCache.m
+//  STNetTaskQueue
+//
+//  Created by Oleg Sorochich on 7/3/16.
+//  Copyright © 2016 Sth4Me. All rights reserved.
+//
+
+#import "STWebCache.h"
+#import "STWebURLResponse.h"
+
+static NSString *const kStorageName = @"WebCache";
+static NSString *const kCacheDaysDurationKey = @"kDurationKey";
+
+@implementation STWebCache
+
+@dynamic cacheDaysDuration;
+
++ (STWebCache *)sharedInstance {
+    
+    static STWebCache *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[STWebCache alloc] init];
+        //sInstance = [[HOWebCache alloc] initWithStoreName:kStorageName];
+    });
+    return sharedInstance;
+}
+
+- (void)setCacheDaysDuration:(NSUInteger)cacheDaysDuration {
+    [self cleanUnusedResponses];
+    [[NSUserDefaults standardUserDefaults] setInteger:cacheDaysDuration
+                                               forKey:kCacheDaysDurationKey];
+}
+
+- (NSUInteger)cacheDaysDuration {
+    NSUInteger duration = [[NSUserDefaults standardUserDefaults] integerForKey:kCacheDaysDurationKey];
+    if (duration < 1) {
+        // A duration for the cached responsed is equal to 3 by default
+        self.cacheDaysDuration = 3;
+        duration = 3;
+    }
+    
+    return duration;
+}
+
+- (void)saveURLResponseWithData:(NSData *)data forURL:(NSString*)url {
+    [self executeBlockInPrivate:^() {
+        STWebURLResponse *item = [self recordsWithName:NSStringFromClass([STWebURLResponse class])
+                                             predicate:[NSPredicate predicateWithFormat:@"url == [c]%@", url]].lastObject;
+        if(item == nil) {
+            item = [self insertObjectWithClass:[STWebURLResponse class]];
+            item.url = url;
+        }
+        
+        item.data = data;
+        item.lastReadDate = [NSDate date];
+       
+        [self save];
+        
+        return (id)nil;
+    }];
+}
+
+- (NSData *)responseDataForUrl:(NSString *)url {
+    return [self executeBlockInPrivate:^() {
+        STWebURLResponse *response = [self recordsWithName:NSStringFromClass([STWebURLResponse class])
+                                                predicate:[NSPredicate predicateWithFormat:@"url == [c]%@", url]].lastObject;
+        NSData *data = response.data;
+        return data;
+    }];
+}
+
+#pragma mark - Private interface
+
+- (void)cleanUnusedResponses {
+    NSTimeInterval const kCleanInterval = 60 * 60 * 24 * self.cacheDaysDuration;
+  
+    [self executeBlockInPrivate:^() {
+        NSDate *oldDate = [NSDate dateWithTimeIntervalSinceNow:-kCleanInterval];
+        NSArray *records = [self recordsWithName:NSStringFromClass([STWebURLResponse class])
+                                       predicate:[NSPredicate predicateWithFormat:@"lastReadDate < %@", oldDate]];
+        NSNumber *count = @(records.count);
+        
+        [self deleteRecords:records];
+        [self save];
+        return (id)count;
+    }];
+}
+
+@end

--- a/STNetTaskQueue/STWebCache.m
+++ b/STNetTaskQueue/STWebCache.m
@@ -22,14 +22,15 @@ static NSString *const kCacheDaysDurationKey = @"kDurationKey";
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         sharedInstance = [[STWebCache alloc] initWithStoreName:kStorageName];
+        [sharedInstance clean];
     });
     return sharedInstance;
 }
 
 - (void)setCacheDaysDuration:(NSUInteger)cacheDaysDuration {
-    [self cleanUnusedResponses];
     [[NSUserDefaults standardUserDefaults] setInteger:cacheDaysDuration
                                                forKey:kCacheDaysDurationKey];
+    [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 - (NSUInteger)cacheDaysDuration {
@@ -72,7 +73,7 @@ static NSString *const kCacheDaysDurationKey = @"kDurationKey";
 
 #pragma mark - Private interface
 
-- (void)cleanUnusedResponses {
+- (void)clean {
     NSTimeInterval const kCleanInterval = 60 * 60 * 24 * self.cacheDaysDuration;
   
     [self executeBlockInPrivate:^() {

--- a/STNetTaskQueue/STWebCache.m
+++ b/STNetTaskQueue/STWebCache.m
@@ -21,8 +21,7 @@ static NSString *const kCacheDaysDurationKey = @"kDurationKey";
     static STWebCache *sharedInstance = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        sharedInstance = [[STWebCache alloc] init];
-        //sInstance = [[HOWebCache alloc] initWithStoreName:kStorageName];
+        sharedInstance = [[STWebCache alloc] initWithStoreName:kStorageName];
     });
     return sharedInstance;
 }
@@ -44,7 +43,7 @@ static NSString *const kCacheDaysDurationKey = @"kDurationKey";
     return duration;
 }
 
-- (void)saveURLResponseWithData:(NSData *)data forURL:(NSString*)url {
+- (void)saveResponseWithData:(NSData *)data forURL:(NSString *)url {
     [self executeBlockInPrivate:^() {
         STWebURLResponse *item = [self recordsWithName:NSStringFromClass([STWebURLResponse class])
                                              predicate:[NSPredicate predicateWithFormat:@"url == [c]%@", url]].lastObject;

--- a/STNetTaskQueue/STWebURLResponse.h
+++ b/STNetTaskQueue/STWebURLResponse.h
@@ -1,0 +1,19 @@
+//
+//  STWebURLResponse.h
+//  STNetTaskQueue
+//
+//  Created by Oleg Sorochich on 7/3/16.
+//  Copyright © 2016 Sth4Me. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+
+@interface STWebURLResponse : NSManagedObject
+
+@property (nonatomic, retain) NSString * url;
+@property (nonatomic, retain) NSData * data;
+@property (nonatomic, retain) NSDate * lastReadDate;
+
+@end

--- a/STNetTaskQueue/STWebURLResponse.m
+++ b/STNetTaskQueue/STWebURLResponse.m
@@ -1,0 +1,17 @@
+//
+//  STWebURLResponse.m
+//  STNetTaskQueue
+//
+//  Created by Oleg Sorochich on 7/3/16.
+//  Copyright © 2016 Sth4Me. All rights reserved.
+//
+
+#import "STWebURLResponse.h"
+
+@implementation STWebURLResponse
+
+@dynamic url;
+@dynamic data;
+@dynamic lastReadDate;
+
+@end

--- a/STNetTaskQueue/WebCache.xcdatamodeld/WebCache.xcdatamodel/contents
+++ b/STNetTaskQueue/WebCache.xcdatamodeld/WebCache.xcdatamodel/contents
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15D21" minimumToolsVersion="Xcode 7.0">
+    <entity name="STWebURLResponse" representedClassName="STWebURLResponse" syncable="YES">
+        <attribute name="data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="lastReadDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="STWebURLResponse" positionX="-63" positionY="-18" width="128" height="90"/>
+    </elements>
+</model>


### PR DESCRIPTION
Hi @kevin0571,

I've written you several months ago, but anyway, I'd like to thank you again for such great library :) 
My team and me have been using the library for more than one year and it completely provides what we need.

During development, we've faced with following points we would like to have:
1. Block-based functionality
2. Response caching
3. Avoid to use `STNetTaskQueue`, because for the most part it is enough to use only `STNetTask` for us.

As a result, we would like to create and use a task something like this:
<img width="652" alt="screen shot 2016-07-03 at 8 29 32 pm" src="https://cloud.githubusercontent.com/assets/6944546/16546757/484567c0-415d-11e6-9848-93120affb97c.png">

And also we would like to have a property inside the `STNetTask` to indicate whether response should be cached or not.

I’ve decided to share with you my finding regarding these points. I’m not sure, whether it will be useful for you as well as for us or not, but anyway, it will be great to get your feedback regarding this.

Thank you!
